### PR TITLE
capture process output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
         args: ["--line-length=120"]
-        language_version: python3.9
+        language_version: python3.10
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/taskbadger/cli.py
+++ b/taskbadger/cli.py
@@ -113,6 +113,7 @@ def _update_task(task, status=None, **data_kwargs):
         else:
             task_data[key] = value
 
+    print(task_data)
     try:
         task.update(status=status, data=task_data or None)
     except Exception as e:

--- a/taskbadger/process.py
+++ b/taskbadger/process.py
@@ -1,0 +1,72 @@
+import subprocess
+import threading
+import time
+from datetime import datetime
+
+
+class ProcessRunner:
+    def __init__(self, process_args, env, capture_output: bool, update_frequency: int = 5):
+        self.process_args = process_args
+        self.env = env
+        self.capture_output = capture_output
+        self.update_frequency = update_frequency
+        self.returncode = None
+
+    def run(self):
+        last_update = datetime.utcnow()
+
+        kwargs = {}
+        if self.capture_output:
+            kwargs["stdout"] = subprocess.PIPE
+            kwargs["stderr"] = subprocess.PIPE
+
+        process = subprocess.Popen(self.process_args, env=self.env, shell=True, **kwargs)
+        if self.capture_output:
+            stdout = Reader(process.stdout).start()
+            stderr = Reader(process.stderr).start()
+
+        while process.poll() is None:
+            time.sleep(0.1)
+            if _should_update(last_update, self.update_frequency):
+                last_update = datetime.utcnow()
+                if self.capture_output:
+                    yield {"stdout": stdout.read(), "stderr": stderr.read()}
+                else:
+                    yield
+
+        self.returncode = process.returncode
+
+
+class Reader:
+    def __init__(self, source):
+        self.source = source
+        self.data = []
+        self._lock = threading.Lock()
+
+    def start(self):
+        self._thread = threading.Thread(name="reader-thread", target=self._reader, daemon=True)
+        self._thread.start()
+        return self
+
+    def _reader(self):
+        """Read data from source until EOF, adding it to collector."""
+        while True:
+            data = self.source.read1().decode()
+            self._lock.acquire()
+            self.data.append(data)
+            self._lock.release()
+            if not data:
+                break
+        return
+
+    def read(self):
+        """Read data written by the process to its standard output."""
+        self._lock.acquire()
+        outdata = "".join(self.data)
+        del self.data[:]
+        self._lock.release()
+        return outdata
+
+
+def _should_update(last_update: datetime, update_frequency_seconds):
+    return (datetime.utcnow() - last_update).total_seconds() >= update_frequency_seconds

--- a/taskbadger/process.py
+++ b/taskbadger/process.py
@@ -34,6 +34,9 @@ class ProcessRunner:
                 else:
                     yield
 
+        if self.capture_output and (stdout or stderr):
+            yield {"stdout": stdout.read(), "stderr": stderr.read()}
+
         self.returncode = process.returncode
 
 
@@ -66,6 +69,9 @@ class Reader:
         del self.data[:]
         self._lock.release()
         return outdata
+
+    def __bool__(self):
+        return bool(self.data)
 
 
 def _should_update(last_update: datetime, update_frequency_seconds):


### PR DESCRIPTION
Adds the ability to capture the process output when using the CLI. 'stdout' and 'stderr' are both captured and appended to the task metadata.