### PR TITLE
ability to accept addition task arguments for celery tasks

### DIFF
--- a/taskbadger/celery.py
+++ b/taskbadger/celery.py
@@ -11,6 +11,8 @@ from .sdk import DefaultMergeStrategy, get_task
 KWARG_PREFIX = "taskbadger_"
 TB_KWARGS_ARG = KWARG_PREFIX + "kwargs"
 
+TERMINAL_STATES = {StatusEnum.SUCCESS, StatusEnum.ERROR, StatusEnum.CANCELLED, StatusEnum.STALE}
+
 log = logging.getLogger("taskbadger")
 
 
@@ -127,6 +129,10 @@ def _update_task(signal_sender, status, einfo=None):
 
     task = signal_sender.taskbadger_task
     if not task:
+        return
+
+    if task.status in TERMINAL_STATES:
+        # ignore tasks that have already been set to a terminal state (probably in the task body)
         return
 
     enter_session()

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -200,3 +200,25 @@ def test_task_signature(celery_session_worker, bind_settings):
     assert get_task.call_count == 3
     assert update.call_count == 6
     assert Badger.current.session().client is None
+
+
+def test_celery_task_already_in_terminal_state(celery_session_worker, bind_settings):
+    @celery.shared_task(bind=True, base=Task)
+    def add_manual_update(self, a, b, is_retry=False):
+        # simulate updating the task to a terminal state
+        self.request.update({"taskbadger_task": task_for_test(status=StatusEnum.SUCCESS)})
+        return a + b
+
+    celery_session_worker.reload()
+
+    with mock.patch("taskbadger.celery.create_task_safe") as create, mock.patch(
+        "taskbadger.celery.update_task_safe"
+    ) as update, mock.patch("taskbadger.celery.get_task") as get_task:
+        get_task.return_value = task_for_test()
+        result = add_manual_update.delay(2, 2)
+        assert result.get(timeout=10, propagate=True) == 4
+
+    assert create.call_count == 1
+    assert update.call_args_list == [
+        mock.call(mock.ANY, status=StatusEnum.PROCESSING, data=mock.ANY),
+    ]


### PR DESCRIPTION
Task Badger task args can be passed via `.apply_async` or via the task decorator by prefixing them with `taskbadger_` or using the `taskbadger_kwargs` keyword argument:

```python

@app.task(base=taskbadger.celery.Task, taskbadger_monitor_id="xyz")
def my_task(x):
    ...

my_task.apply_async(x, taskbadger_value_max=len(x), taskbadger_kwargs={"data": {
    "custom_key": "custom_value"
}})
```