### PR TITLE
add concept of scope to store global task data

### DIFF
--- a/taskbadger/__init__.py
+++ b/taskbadger/__init__.py
@@ -1,3 +1,4 @@
+from .decorators import track
 from .integrations import Action, EmailIntegration, WebhookIntegration
 from .internal.models import StatusEnum
 from .mug import Badger, Session

--- a/taskbadger/__init__.py
+++ b/taskbadger/__init__.py
@@ -1,7 +1,6 @@
-from .decorators import track
 from .integrations import Action, EmailIntegration, WebhookIntegration
 from .internal.models import StatusEnum
-from .mug import Session
+from .mug import Badger, Session
 from .safe_sdk import create_task_safe, update_task_safe
 from .sdk import DefaultMergeStrategy, Task, create_task, get_task, init, update_task
 
@@ -15,3 +14,7 @@ try:
     __version__ = importlib_metadata.version(__name__)
 except importlib_metadata.PackageNotFoundError:
     __version__ = "dev"
+
+
+def with_scope():
+    return Badger.current.scope()

--- a/taskbadger/__init__.py
+++ b/taskbadger/__init__.py
@@ -16,5 +16,5 @@ except importlib_metadata.PackageNotFoundError:
     __version__ = "dev"
 
 
-def with_scope():
+def current_scope():
     return Badger.current.scope()

--- a/taskbadger/sdk.py
+++ b/taskbadger/sdk.py
@@ -100,8 +100,10 @@ def create_task(
     task = TaskRequest(
         name=name, status=status, value=value, value_max=value_max, max_runtime=max_runtime, stale_timeout=stale_timeout
     )
-    if data:
-        task.data = TaskRequestData.from_dict(data)
+    scope_data = Badger.current.scope().context
+    if scope_data or data:
+        data = data or {}
+        task.data = TaskRequestData.from_dict({**scope_data, **data})
     if actions:
         task.additional_properties = {"actions": [a.to_dict() for a in actions]}
     kwargs = _make_args(json_body=task)

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,58 @@
+import random
+import threading
+import time
+
+import pytest
+
+from taskbadger import create_task, init
+from taskbadger.mug import GLOBAL_MUG, Badger
+from tests.test_sdk_primatives import _json_task_response, _verify_task
+
+
+def test_scope_singleton():
+    assert Badger.current == GLOBAL_MUG
+    scope = Badger.current.scope()
+    assert scope.context == {}
+    assert scope.stack == []
+    assert scope == Badger.current.scope()
+
+
+def test_scope_context():
+    scope = Badger.current.scope()
+    assert scope.context == {}
+    assert scope.stack == []
+    with scope:
+        assert scope.stack == [{}]
+        scope.context["foo"] = "bar"
+        with scope:
+            assert scope.stack == [{}, {"foo": "bar"}]
+            assert scope.context == {"foo": "bar"}
+            scope.context["bar"] = "bazz"
+            with scope:
+                assert scope.context == {"foo": "bar", "bar": "bazz"}
+                scope.context.clear()
+        assert scope.context == {"foo": "bar"}
+        assert scope.stack == [{}]
+    assert scope.context == {}
+    assert scope.stack == []
+
+
+@pytest.fixture(autouse=True)
+def init_skd():
+    init("org", "project", "token")
+
+
+def test_create_task_with_scope(httpx_mock):
+    with Badger.current.scope() as scope:
+        scope["foo"] = "bar"
+        scope["bar"] = "bazz"
+        httpx_mock.add_response(
+            url="https://taskbadger.net/api/org/project/tasks/",
+            method="POST",
+            match_headers={"Authorization": "Bearer token"},
+            match_content=b'{"name": "name", "status": "pending", "data": {"foo": "bar", "bar": "buzzer"}}',
+            json=_json_task_response(),
+            status_code=201,
+        )
+        task = create_task("name", data={"bar": "buzzer"})
+        _verify_task(task)


### PR DESCRIPTION
Provide data to tasks without the need to pass it in directly to every call.
```
from taskbadger import current_scope, create_task

with current_scope() as scope:
    scope["foo"] = "bar"
    create_task("my task 1")
    create_task("my task 2")
    create_task("my task 3")
```