### PR TITLE
Fix serialization error when TB is installed but not configured

### DIFF
--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -171,7 +171,14 @@ def test_celery_task_badger_not_configured(celery_session_app, celery_session_wo
     with mock.patch("taskbadger.celery.create_task_safe") as create, mock.patch(
         "taskbadger.celery.update_task_safe"
     ) as update:
-        result = add_no_tb.delay(2, 2)
+        result = add_no_tb.delay(
+            2,
+            2,
+            taskbadger_kwargs={
+                # add an action here to test serialization failure when Badger is not configured
+                "actions": [Action("stale", integration=EmailIntegration(to="test@test.com"))]
+            },
+        )
         assert result.get(timeout=10, propagate=True) == 4
 
     create.assert_not_called()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -71,6 +71,8 @@ def test_session_multiple_threads():
 
 
 class TestThread(threading.Thread):
+    __test__ = False
+
     def __init__(self, name, barrier, clients):
         threading.Thread.__init__(self, name=name)
         self.barrier = barrier


### PR DESCRIPTION
This fixes a serialization bug if Actions are included
in the TB configuration when TB is not being used since they are not JSON
serializable