### PR TITLE
Remove deprecated update_progress / increment_progress

### DIFF
--- a/taskbadger/sdk.py
+++ b/taskbadger/sdk.py
@@ -367,14 +367,6 @@ class Task:
         """Update the task status"""
         self.update(status=status)
 
-    def increment_progress(self, amount: int):
-        warnings.warn(
-            "'task.increment_progress' will be removed in v1.7.0. Use 'task.increment_value' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.increment_value(amount)
-
     def increment_value(self, amount: int):
         """Increment the task progress by adding the specified amount to the current value.
         If the task value is not set it will be set to `amount`.
@@ -383,14 +375,6 @@ class Task:
         value_norm = value if value is not UNSET and value is not None else 0
         new_amount = value_norm + amount
         self.update(value=new_amount)
-
-    def update_progress(self, value: int, value_step: int = None, rate_limit: int = None):
-        warnings.warn(
-            "'task.update_progress' will be removed in v1.7.0. Use 'task.update_value' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.update_value(value, value_step, rate_limit)
 
     def update_value(self, value: int, value_step: int = None, rate_limit: int = None) -> bool:
         """Update task progress.

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -190,7 +190,7 @@ def test_ping(settings, patched_update):
     assert len(patched_update.call_args_list) == 2
 
 
-def test_update_progress_rate_limit(settings, patched_update):
+def test_update_value_rate_limit(settings, patched_update):
     task = Task(task_for_test(value=1))
 
     updated_at = task.updated
@@ -210,56 +210,43 @@ def test_update_progress_rate_limit(settings, patched_update):
     assert len(patched_update.call_args_list) == 2
 
 
-def test_update_progress_value_step(settings, patched_update):
+def test_update_value_value_step(settings, patched_update):
     task = Task(task_for_test(value=1))
 
     patched_update.return_value = Response(HTTPStatus.OK, b"", {}, task_for_test(value=4))
-    task.update_progress(4, value_step=5)
+    task.update_value(4, value_step=5)
     assert len(patched_update.call_args_list) == 0
 
-    task.update_progress(4)
+    task.update_value(4)
     _verify_update(settings, patched_update, value=4)
 
-    task.update_progress(8, value_step=5)
+    task.update_value(8, value_step=5)
     assert len(patched_update.call_args_list) == 1
 
-    task.update_progress(9, value_step=5)
+    task.update_value(9, value_step=5)
     assert len(patched_update.call_args_list) == 2
 
 
-def test_update_progress_min_interval_both(settings, patched_update):
+def test_update_value_min_interval_both(settings, patched_update):
     task = Task(task_for_test(value=1))
 
     patched_update.return_value = Response(HTTPStatus.OK, b"", {}, task_for_test(value=4))
     # neither checks pass
-    task.update_progress(4, rate_limit=1, value_step=5)
+    task.update_value(4, rate_limit=1, value_step=5)
     assert len(patched_update.call_args_list) == 0
 
     # value check passes
-    task.update_progress(6, rate_limit=1, value_step=5)
+    task.update_value(6, rate_limit=1, value_step=5)
     _verify_update(settings, patched_update, value=6)
 
     # neither checks pass
-    task.update_progress(8, rate_limit=1, value_step=5)
+    task.update_value(8, rate_limit=1, value_step=5)
     assert len(patched_update.call_args_list) == 1
 
     # time check passes
     task._task.updated = task._task.updated - datetime.timedelta(seconds=1)
-    task.update_progress(6, rate_limit=1, value_step=5)
+    task.update_value(6, rate_limit=1, value_step=5)
     assert len(patched_update.call_args_list) == 2
-
-
-def test_increment_progress(settings, patched_update):
-    api_task = task_for_test()
-    task = Task(api_task)
-
-    patched_update.return_value = Response(HTTPStatus.OK, b"", {}, task_for_test(value=10))
-
-    task.increment_progress(10)
-    _verify_update(settings, patched_update, value=10)
-
-    task.increment_progress(10)
-    _verify_update(settings, patched_update, value=20)
 
 
 def test_update_timeouts(settings, patched_update):


### PR DESCRIPTION
## Summary
- Remove `Task.update_progress` and `Task.increment_progress` (both DeprecationWarning'd to be removed in v1.7.0; package is now on 1.7.0)
- Update tests to call `update_value` / `increment_value` directly and rename test functions
- Drop a now-redundant duplicate `test_increment_value`

## Migration
The replacements are signature-compatible:

```python
task.update_progress(value, value_step=..., rate_limit=...)  → task.update_value(value, value_step=..., rate_limit=...)
task.increment_progress(amount)                              → task.increment_value(amount)
```

This is a breaking change; the next release should be **v1.8.0**.

## Test plan
- [x] `pytest tests/test_sdk.py` — 14/14 pass
- [x] No remaining references to `update_progress` / `increment_progress`

🤖 Generated with [Claude Code](https://claude.com/claude-code)