### PR TITLE
chore: prep 2.1.0a1 alpha release with procrastinate support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           enable-cache: true
       - name: Add version to environment vars
         run: |
-          PROJECT_VERSION=$(uvx dunamai from any --format "{base}")
+          PROJECT_VERSION=$(uvx dunamai from any)
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
       - name: Check if tag version matches project version
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taskbadger"
-version = "2.0.0"
+version = "2.1.0a1"
 description = "The official Python SDK for Task Badger"
 requires-python = ">=3.10"
 authors = []


### PR DESCRIPTION
## Summary
- Bumps version to **2.1.0a1** so the procrastinate integration (#46) can ship as a PEP 440 alpha for early users. PyPI installs only with \`--pre\`, leaving the next stable 2.1.0 uncommitted.
- Drops \`--format \"{base}\"\` from the dunamai call in \`release.yml\`. \`{base}\` strips the pre-release suffix and broke two things:
  - the tag/version equality check (\`v2.1.0a1\` != \`v2.1.0\`)
  - the artifact-upload path — built wheels are named \`taskbadger-2.1.0a1-*\`, but the workflow looked for \`taskbadger-2.1.0-*\`

Default dunamai output is already PEP 440, so the fix is general: beta/rc tags will also work going forward.

## Release flow after this merges
1. Merge this PR to \`main\`.
2. Tag: \`git tag v2.1.0a1 && git push origin v2.1.0a1\`.
3. The \`release.yml\` workflow builds, runs tests, drafts a GitHub release.
4. Publishing the draft release triggers \`publish.yml\` → PyPI (uploads as a pre-release; \`pip install taskbadger\` still gets 2.0.0 unless users pass \`--pre\`).

## Test plan
- [x] \`uv build\` locally produces \`taskbadger-2.1.0a1-py3-none-any.whl\` and \`.tar.gz\`
- [ ] CI passes on this PR
- [ ] After tagging, verify the release workflow's version-check step passes (tag \`v2.1.0a1\` == \`PROJECT_VERSION\` \`2.1.0a1\`)
- [ ] After publishing the draft release, confirm PyPI shows 2.1.0a1 as a pre-release and \`pip install --pre taskbadger\` resolves to it