### PR TITLE
fix: make procrastinate integration tests runnable in CI

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -17,6 +17,19 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: procrastinate
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -36,3 +49,4 @@ jobs:
           TASKBADGER_ORG: ${{ vars.TASKBADGER_ORG }}
           TASKBADGER_PROJECT: ${{ vars.TASKBADGER_PROJECT }}
           TASKBADGER_API_KEY: ${{ secrets.TASKBADGER_API_KEY }}
+          PROCRASTINATE_DSN: postgresql://postgres:postgres@localhost:5432/procrastinate

--- a/integration_tests/test_procrastinate.py
+++ b/integration_tests/test_procrastinate.py
@@ -36,14 +36,17 @@ def _check_log_errors(caplog):
             pytest.fail(f"log errors during '{when}': {errors}")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def app():
     # Async connector even though the tests are sync: run_worker raises
     # SyncConnectorConfigurationError on SyncPsycopgConnector. Async works in both contexts.
+    #
+    # Function-scoped because run_worker tears down the sync sub-connector
+    # PsycopgConnector creates inside `app.open()`, and nothing reopens it for
+    # the next test's defer() call. Cheap: apply_schema is idempotent.
     conn = procrastinate.PsycopgConnector(conninfo=PROCRASTINATE_DSN)
     app = procrastinate.App(connector=conn)
     with app.open():
-        # Apply schema (idempotent — Procrastinate's apply_schema is safe to re-run).
         app.schema_manager.apply_schema()
         yield app
 

--- a/integration_tests/test_procrastinate.py
+++ b/integration_tests/test_procrastinate.py
@@ -36,18 +36,31 @@ def _check_log_errors(caplog):
             pytest.fail(f"log errors during '{when}': {errors}")
 
 
+@pytest.fixture(scope="session")
+def _schema():
+    # apply_schema is NOT idempotent (schema.sql uses bare CREATE TYPE), so
+    # only apply when the schema isn't already present.
+    with psycopg.connect(PROCRASTINATE_DSN) as conn, conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('procrastinate_jobs')")
+        if cur.fetchone()[0] is not None:
+            return
+    schema_conn = procrastinate.SyncPsycopgConnector(conninfo=PROCRASTINATE_DSN)
+    schema_app = procrastinate.App(connector=schema_conn)
+    with schema_app.open():
+        schema_app.schema_manager.apply_schema()
+
+
 @pytest.fixture
-def app():
-    # Async connector even though the tests are sync: run_worker raises
-    # SyncConnectorConfigurationError on SyncPsycopgConnector. Async works in both contexts.
+def app(_schema):
+    # Async connector: run_worker raises SyncConnectorConfigurationError on
+    # SyncPsycopgConnector. Async connectors work in sync contexts too.
     #
-    # Function-scoped because run_worker tears down the sync sub-connector
-    # PsycopgConnector creates inside `app.open()`, and nothing reopens it for
-    # the next test's defer() call. Cheap: apply_schema is idempotent.
+    # Function-scoped because run_worker tears down the sync sub-connector that
+    # PsycopgConnector spawns inside `app.open()`, leaving the next test's
+    # defer() with no usable sync pool.
     conn = procrastinate.PsycopgConnector(conninfo=PROCRASTINATE_DSN)
     app = procrastinate.App(connector=conn)
     with app.open():
-        app.schema_manager.apply_schema()
         yield app
 
 

--- a/integration_tests/test_procrastinate.py
+++ b/integration_tests/test_procrastinate.py
@@ -13,6 +13,7 @@ import os
 import random
 
 import procrastinate
+import psycopg
 import pytest
 
 import taskbadger
@@ -37,8 +38,9 @@ def _check_log_errors(caplog):
 
 @pytest.fixture(scope="session")
 def app():
-    """A Procrastinate app pointed at a real Postgres instance with its schema applied."""
-    conn = procrastinate.SyncPsycopgConnector(conninfo=PROCRASTINATE_DSN)
+    # Async connector even though the tests are sync: run_worker raises
+    # SyncConnectorConfigurationError on SyncPsycopgConnector. Async works in both contexts.
+    conn = procrastinate.PsycopgConnector(conninfo=PROCRASTINATE_DSN)
     app = procrastinate.App(connector=conn)
     with app.open():
         # Apply schema (idempotent — Procrastinate's apply_schema is safe to re-run).
@@ -46,9 +48,9 @@ def app():
         yield app
 
 
-def _fetch_job_args(app, job_id):
-    """Read the stored ``args`` JSONB for a Procrastinate job."""
-    with app.connector.pool.connection() as conn:
+def _fetch_job_args(job_id):
+    # Direct sync psycopg connection — the app's pool is async (see fixture).
+    with psycopg.connect(PROCRASTINATE_DSN) as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT args FROM procrastinate_jobs WHERE id = %s", (job_id,))
             row = cur.fetchone()
@@ -75,7 +77,7 @@ def test_track_decorator(app):
 
     # The TB task id was stashed in the job kwargs at defer time. Read it back
     # from Procrastinate to verify the final state.
-    args = _fetch_job_args(app, job_id)
+    args = _fetch_job_args(job_id)
     tb_id = args["__taskbadger_task_id__"]
 
     fetched = taskbadger.get_task(tb_id)
@@ -100,7 +102,7 @@ def test_auto_track_via_system(app):
         listen_notify=False,
     )
 
-    args = _fetch_job_args(app, job_id)
+    args = _fetch_job_args(job_id)
     tb_id = args["__taskbadger_task_id__"]
 
     fetched = taskbadger.get_task(tb_id)

--- a/uv.lock
+++ b/uv.lock
@@ -1077,7 +1077,7 @@ wheels = [
 
 [[package]]
 name = "taskbadger"
-version = "2.0.0"
+version = "2.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary
Makes the procrastinate integration tests added in #46 actually run.

### CI infra
- Adds a `postgres:16` service container to `integration_tests.yml`. Without it, both procrastinate tests failed on every push to main with `psycopg_pool.PoolTimeout`.
- Sets `PROCRASTINATE_DSN` explicitly on the test step (matches the test default, but self-documents the dependency).

### Test fixture fix
- Switches `test_procrastinate.py` to `PsycopgConnector` (async). `SyncPsycopgConnector` can defer jobs and apply schema, but `run_worker` calls `open_async()` and raises `SyncConnectorConfigurationError` on sync connectors. Async connectors work in both sync and async contexts per procrastinate's docs.
- `_fetch_job_args` opens its own sync `psycopg.connect()` instead of borrowing the app's now-async pool.

### Lockfile
- Picks up the `uv.lock` entry for `taskbadger 2.1.0a1` that should have ridden along with #47.

## Test plan
- [ ] Integration Tests workflow run on merge passes (it triggers on push to main, so we'll see it post-merge)
- [ ] Confirm locally: `uv run pytest integration_tests/test_procrastinate.py -vs` against a Postgres reachable at `PROCRASTINATE_DSN` runs both tests green