### PR TITLE
Record originating task ID as external_id

### DIFF
--- a/taskbadger.yaml
+++ b/taskbadger.yaml
@@ -694,6 +694,11 @@ components:
           type: string
           description: Queue the task is from
           maxLength: 255
+        external_id:
+          type: string
+          description: Identifier from the originating system (e.g. Celery task ID)
+            for correlating with logs
+          maxLength: 255
         status:
           allOf:
           - $ref: '#/components/schemas/StatusEnum'
@@ -794,6 +799,11 @@ components:
           type: string
           description: Queue the task is from
           maxLength: 255
+        external_id:
+          type: string
+          description: Identifier from the originating system (e.g. Celery task ID)
+            for correlating with logs
+          maxLength: 255
         status:
           allOf:
           - $ref: '#/components/schemas/StatusEnum'
@@ -892,6 +902,11 @@ components:
         queue:
           type: string
           description: Queue the task is from
+          maxLength: 255
+        external_id:
+          type: string
+          description: Identifier from the originating system (e.g. Celery task ID)
+            for correlating with logs
           maxLength: 255
         status:
           allOf:

--- a/taskbadger/celery.py
+++ b/taskbadger/celery.py
@@ -137,7 +137,9 @@ def task_publish_handler(sender=None, headers=None, body=None, **kwargs):
     ctask = celery.current_app.tasks.get(sender)
 
     # get kwargs from the task class (set via decorator)
-    kwargs = getattr(ctask, TB_KWARGS_ARG, {})
+    # copy: the raw attr is shared across invocations, and we mutate per-publish
+    # values (external_id, status, name) into it below
+    kwargs = dict(getattr(ctask, TB_KWARGS_ARG, {}))
     for attr in dir(ctask):
         if attr.startswith(KWARG_PREFIX) and attr not in IGNORE_ARGS:
             kwargs[attr.removeprefix(KWARG_PREFIX)] = getattr(ctask, attr)
@@ -147,6 +149,7 @@ def task_publish_handler(sender=None, headers=None, body=None, **kwargs):
     kwargs["status"] = StatusEnum.PENDING
     if routing_key and "queue" not in kwargs:
         kwargs["queue"] = routing_key
+    kwargs.setdefault("external_id", headers["id"])
     name = kwargs.pop("name", headers["task"])
 
     global_record_task_args = celery_system and celery_system.record_task_args
@@ -247,7 +250,8 @@ def _maybe_create_task(signal_sender):
 
     delivery_info = getattr(signal_sender.request, "delivery_info", None) or {}
     queue = delivery_info.get("routing_key")
-    task = create_task_safe(task_name, status=StatusEnum.PENDING, data=data, queue=queue)
+    external_id = signal_sender.request.id
+    task = create_task_safe(task_name, status=StatusEnum.PENDING, data=data, queue=queue, external_id=external_id)
     if task:
         # Store the task ID in the request so _update_task can find it
         signal_sender.request.update({TB_TASK_ID: task.id})

--- a/taskbadger/internal/models/patched_task_request.py
+++ b/taskbadger/internal/models/patched_task_request.py
@@ -24,6 +24,8 @@ class PatchedTaskRequest:
     Attributes:
         name (str | Unset): Name of the task
         queue (str | Unset): Queue the task is from
+        external_id (str | Unset): Identifier from the originating system (e.g. Celery task ID) for correlating with
+            logs
         status (StatusEnum | Unset): * `pending` - pending
             * `pre_processing` - pre_processing
             * `processing` - processing
@@ -50,6 +52,7 @@ class PatchedTaskRequest:
 
     name: str | Unset = UNSET
     queue: str | Unset = UNSET
+    external_id: str | Unset = UNSET
     status: StatusEnum | Unset = StatusEnum.PENDING
     value: int | None | Unset = UNSET
     value_max: int | Unset = UNSET
@@ -68,6 +71,8 @@ class PatchedTaskRequest:
         name = self.name
 
         queue = self.queue
+
+        external_id = self.external_id
 
         status: str | Unset = UNSET
         if not isinstance(self.status, Unset):
@@ -128,6 +133,8 @@ class PatchedTaskRequest:
             field_dict["name"] = name
         if queue is not UNSET:
             field_dict["queue"] = queue
+        if external_id is not UNSET:
+            field_dict["external_id"] = external_id
         if status is not UNSET:
             field_dict["status"] = status
         if value is not UNSET:
@@ -159,6 +166,8 @@ class PatchedTaskRequest:
         name = d.pop("name", UNSET)
 
         queue = d.pop("queue", UNSET)
+
+        external_id = d.pop("external_id", UNSET)
 
         _status = d.pop("status", UNSET)
         status: StatusEnum | Unset
@@ -251,6 +260,7 @@ class PatchedTaskRequest:
         patched_task_request = cls(
             name=name,
             queue=queue,
+            external_id=external_id,
             status=status,
             value=value,
             value_max=value_max,

--- a/taskbadger/internal/models/task.py
+++ b/taskbadger/internal/models/task.py
@@ -32,6 +32,8 @@ class Task:
         url (str):
         public_url (str):
         queue (str | Unset): Queue the task is from
+        external_id (str | Unset): Identifier from the originating system (e.g. Celery task ID) for correlating with
+            logs
         status (StatusEnum | Unset): * `pending` - pending
             * `pre_processing` - pre_processing
             * `processing` - processing
@@ -66,6 +68,7 @@ class Task:
     url: str
     public_url: str
     queue: str | Unset = UNSET
+    external_id: str | Unset = UNSET
     status: StatusEnum | Unset = StatusEnum.PENDING
     value: int | None | Unset = UNSET
     value_max: int | Unset = UNSET
@@ -101,6 +104,8 @@ class Task:
         public_url = self.public_url
 
         queue = self.queue
+
+        external_id = self.external_id
 
         status: str | Unset = UNSET
         if not isinstance(self.status, Unset):
@@ -171,6 +176,8 @@ class Task:
         )
         if queue is not UNSET:
             field_dict["queue"] = queue
+        if external_id is not UNSET:
+            field_dict["external_id"] = external_id
         if status is not UNSET:
             field_dict["status"] = status
         if value is not UNSET:
@@ -223,6 +230,8 @@ class Task:
         public_url = d.pop("public_url")
 
         queue = d.pop("queue", UNSET)
+
+        external_id = d.pop("external_id", UNSET)
 
         _status = d.pop("status", UNSET)
         status: StatusEnum | Unset
@@ -323,6 +332,7 @@ class Task:
             url=url,
             public_url=public_url,
             queue=queue,
+            external_id=external_id,
             status=status,
             value=value,
             value_max=value_max,

--- a/taskbadger/internal/models/task_request.py
+++ b/taskbadger/internal/models/task_request.py
@@ -24,6 +24,8 @@ class TaskRequest:
     Attributes:
         name (str): Name of the task
         queue (str | Unset): Queue the task is from
+        external_id (str | Unset): Identifier from the originating system (e.g. Celery task ID) for correlating with
+            logs
         status (StatusEnum | Unset): * `pending` - pending
             * `pre_processing` - pre_processing
             * `processing` - processing
@@ -50,6 +52,7 @@ class TaskRequest:
 
     name: str
     queue: str | Unset = UNSET
+    external_id: str | Unset = UNSET
     status: StatusEnum | Unset = StatusEnum.PENDING
     value: int | None | Unset = UNSET
     value_max: int | Unset = UNSET
@@ -68,6 +71,8 @@ class TaskRequest:
         name = self.name
 
         queue = self.queue
+
+        external_id = self.external_id
 
         status: str | Unset = UNSET
         if not isinstance(self.status, Unset):
@@ -130,6 +135,8 @@ class TaskRequest:
         )
         if queue is not UNSET:
             field_dict["queue"] = queue
+        if external_id is not UNSET:
+            field_dict["external_id"] = external_id
         if status is not UNSET:
             field_dict["status"] = status
         if value is not UNSET:
@@ -161,6 +168,8 @@ class TaskRequest:
         name = d.pop("name")
 
         queue = d.pop("queue", UNSET)
+
+        external_id = d.pop("external_id", UNSET)
 
         _status = d.pop("status", UNSET)
         status: StatusEnum | Unset
@@ -253,6 +262,7 @@ class TaskRequest:
         task_request = cls(
             name=name,
             queue=queue,
+            external_id=external_id,
             status=status,
             value=value,
             value_max=value_max,

--- a/taskbadger/procrastinate.py
+++ b/taskbadger/procrastinate.py
@@ -149,12 +149,16 @@ def _wrap_defer(task):
     @functools.wraps(original_defer)
     def defer(**kwargs):
         kwargs = _maybe_create_pending(task, kwargs)
-        return original_defer(**kwargs)
+        job_id = original_defer(**kwargs)
+        _record_external_id(kwargs, job_id)
+        return job_id
 
     @functools.wraps(original_defer_async)
     async def defer_async(**kwargs):
         kwargs = _maybe_create_pending(task, kwargs)
-        return await original_defer_async(**kwargs)
+        job_id = await original_defer_async(**kwargs)
+        _record_external_id(kwargs, job_id)
+        return job_id
 
     task.defer = defer
     task.defer_async = defer_async
@@ -212,6 +216,18 @@ def _maybe_create_pending(task, kwargs):
     new_kwargs = dict(kwargs)
     new_kwargs[TB_TASK_ID_KWARG] = tb_task.id
     return new_kwargs
+
+
+def _record_external_id(kwargs, job_id):
+    """Record the Procrastinate job id as the TaskBadger task's ``external_id``.
+
+    ``defer`` only returns the DB-assigned job id once the job is enqueued, so this
+    runs as a follow-up update after both ids are known. No-op if the defer wasn't
+    tracked (no injected id) or no job id came back."""
+    tb_id = kwargs.get(TB_TASK_ID_KWARG)
+    if tb_id is None or job_id is None:
+        return
+    update_task_safe(tb_id, external_id=str(job_id))
 
 
 def _serialize_kwargs(kwargs):
@@ -296,14 +312,19 @@ def _patch_job_manager(app, system):
         @functools.wraps(original)
         async def patched(*, job, periodic_id, defer_timestamp):
             task = app.tasks.get(job.task_name)
+            tb_id = None
             if task is not None:
                 tb_task = _create_pending_task(task, job.task_kwargs, queue=job.queue)
                 if tb_task is not None:
                     new_kwargs = {**job.task_kwargs, TB_TASK_ID_KWARG: tb_task.id}
                     job = job.evolve(task_kwargs=new_kwargs)
-            return await jm._taskbadger_original_defer_periodic_job(
+                    tb_id = tb_task.id
+            job_id = await jm._taskbadger_original_defer_periodic_job(
                 job=job, periodic_id=periodic_id, defer_timestamp=defer_timestamp
             )
+            if tb_id is not None and job_id is not None:
+                update_task_safe(tb_id, external_id=str(job_id))
+            return job_id
 
         jm.defer_periodic_job = patched
 

--- a/taskbadger/sdk.py
+++ b/taskbadger/sdk.py
@@ -152,6 +152,7 @@ def create_task(
     monitor_id: str = None,
     tags: dict[str, str] = None,
     queue: str = None,
+    external_id: str = None,
 ) -> "Task":
     """Create a Task.
 
@@ -167,6 +168,7 @@ def create_task(
         monitor_id: ID of the monitor to associate this task with.
         tags: Dictionary of namespace -> value tags.
         queue: Name of the queue the task is from.
+        external_id: Identifier from the originating system (e.g. Celery task ID) for correlating with logs.
 
     Returns:
         Task: The created Task object.
@@ -177,6 +179,8 @@ def create_task(
     }
     if queue is not None:
         task_dict["queue"] = queue
+    if external_id is not None:
+        task_dict["external_id"] = external_id
     if value is not None:
         task_dict["value"] = value
     if value_max is not None:
@@ -222,6 +226,7 @@ def update_task(
     actions: list[Action] = None,
     tags: dict[str, str] = None,
     queue: str = None,
+    external_id: str = None,
 ) -> "Task":
     """Update a task.
     Requires only the task ID and fields to update.
@@ -238,6 +243,7 @@ def update_task(
         actions: Task actions. **Deprecated:** use project-level actions instead.
         tags: Dictionary of namespace -> value tags.
         queue: Name of the queue the task is from.
+        external_id: Identifier from the originating system (e.g. Celery task ID) for correlating with logs.
 
     Returns:
         Task: The updated Task object.
@@ -250,6 +256,7 @@ def update_task(
     max_runtime = _none_to_unset(max_runtime)
     stale_timeout = _none_to_unset(stale_timeout)
     queue = _none_to_unset(queue)
+    external_id = _none_to_unset(external_id)
 
     data = data or UNSET
     body = PatchedTaskRequest(
@@ -261,6 +268,7 @@ def update_task(
         max_runtime=max_runtime,
         stale_timeout=stale_timeout,
         queue=queue,
+        external_id=external_id,
     )
     if actions:
         _warn_actions_deprecated()
@@ -335,6 +343,7 @@ class Task:
         monitor_id: str = None,
         tags: dict[str, str] = None,
         queue: str = None,
+        external_id: str = None,
     ) -> "Task":
         """Create a new task
 
@@ -352,6 +361,7 @@ class Task:
             monitor_id=monitor_id,
             tags=tags,
             queue=queue,
+            external_id=external_id,
         )
 
     def __init__(self, task):
@@ -437,6 +447,7 @@ class Task:
         actions: list[Action] = None,
         tags: dict[str, str] = None,
         queue: str = None,
+        external_id: str = None,
         data_merge_strategy: Any = None,
     ):
         """Generic update method used to update any of the task fields.
@@ -465,6 +476,7 @@ class Task:
             actions=actions,
             tags=tags,
             queue=queue,
+            external_id=external_id,
         )
         self._task = task._task
 

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -98,7 +98,13 @@ def test_celery_task_with_args(celery_session_app, celery_session_worker):
         assert result.get(timeout=10, propagate=True) == 4
 
     create.assert_called_once_with(
-        "new_name", value_max=10, data={"foo": "bar"}, tags={"bar": "baz"}, status=StatusEnum.PENDING, queue="celery"
+        "new_name",
+        value_max=10,
+        data={"foo": "bar"},
+        tags={"bar": "baz"},
+        status=StatusEnum.PENDING,
+        queue="celery",
+        external_id=mock.ANY,
     )
 
 
@@ -128,7 +134,9 @@ def test_celery_task_with_kwargs(celery_session_app, celery_session_worker):
         )
         assert result.get(timeout=10, propagate=True) == 4
 
-    create.assert_called_once_with("new_name", value_max=10, actions=actions, status=StatusEnum.PENDING, queue="celery")
+    create.assert_called_once_with(
+        "new_name", value_max=10, actions=actions, status=StatusEnum.PENDING, queue="celery", external_id=mock.ANY
+    )
 
 
 @pytest.mark.usefixtures("_bind_settings")
@@ -162,6 +170,7 @@ def test_celery_record_args(celery_session_app, celery_session_worker):
         data={"foo": "bar", "celery_task_args": [2, 2], "celery_task_kwargs": {}},
         status=StatusEnum.PENDING,
         queue="celery",
+        external_id=mock.ANY,
     )
 
 
@@ -200,6 +209,7 @@ def test_celery_record_task_kwargs(celery_session_app, celery_session_worker):
         actions=actions,
         status=StatusEnum.PENDING,
         queue="celery",
+        external_id=mock.ANY,
     )
 
 
@@ -237,6 +247,7 @@ def test_celery_record_task_args_custom_serialization(celery_session_app, celery
         data={"celery_task_args": [{"__type__": "A", "__value__": [2, 2]}], "celery_task_kwargs": {}},
         status=StatusEnum.PENDING,
         queue="celery",
+        external_id=mock.ANY,
     )
 
 
@@ -264,7 +275,9 @@ def test_celery_task_with_args_in_decorator(celery_session_app, celery_session_w
         result = add_with_task_args_in_decorator.delay(2, 2)
         assert result.get(timeout=10, propagate=True) == 4
 
-    create.assert_called_once_with(mock.ANY, status=StatusEnum.PENDING, monitor_id="123", value_max=10, queue="celery")
+    create.assert_called_once_with(
+        mock.ANY, status=StatusEnum.PENDING, monitor_id="123", value_max=10, queue="celery", external_id=mock.ANY
+    )
 
 
 @pytest.mark.usefixtures("_bind_settings")
@@ -286,6 +299,49 @@ def test_celery_task_custom_queue(celery_session_app, celery_session_worker):
         add_custom_queue.apply_async((2, 2), queue="high_priority")
 
     assert create.call_args.kwargs["queue"] == "high_priority"
+
+
+@pytest.mark.usefixtures("_bind_settings")
+def test_celery_records_task_id_as_external_id(celery_session_app, celery_session_worker):
+    @celery_session_app.task(bind=True, base=Task)
+    def add_external_id(self, a, b):
+        return a + b
+
+    celery_session_worker.reload()
+
+    with (
+        mock.patch("taskbadger.celery.create_task_safe") as create,
+        mock.patch("taskbadger.celery.update_task_safe"),
+        mock.patch("taskbadger.sdk.get_task"),
+    ):
+        create.return_value = task_for_test()
+        result = add_external_id.apply_async((2, 2), queue="high_priority")
+
+    assert create.call_args.kwargs["external_id"] == result.id
+
+
+@pytest.mark.usefixtures("_bind_settings")
+def test_celery_external_id_not_cached_across_invocations(celery_session_app, celery_session_worker):
+    # Tasks defined with taskbadger_kwargs share a class-level dict; external_id
+    # must not leak from one publish to the next.
+    @celery_session_app.task(bind=True, base=Task, taskbadger_kwargs={"value_max": 10})
+    def add_repeat(self, a, b):
+        return a + b
+
+    celery_session_worker.reload()
+
+    with (
+        mock.patch("taskbadger.celery.create_task_safe") as create,
+        mock.patch("taskbadger.celery.update_task_safe"),
+        mock.patch("taskbadger.sdk.get_task"),
+    ):
+        create.return_value = task_for_test()
+        result1 = add_repeat.apply_async((2, 2), queue="high_priority")
+        result2 = add_repeat.apply_async((3, 3), queue="high_priority")
+
+    external_ids = [c.kwargs["external_id"] for c in create.call_args_list]
+    assert external_ids == [result1.id, result2.id]
+    assert result1.id != result2.id
 
 
 @pytest.mark.usefixtures("_bind_settings")

--- a/tests/test_celery_system_integration.py
+++ b/tests/test_celery_system_integration.py
@@ -123,6 +123,7 @@ def test_celery_record_task_args(celery_session_app, celery_session_worker):
         status=StatusEnum.PENDING,
         data={"celery_task_args": [2, 2], "celery_task_kwargs": {}},
         queue="celery",
+        external_id=mock.ANY,
     )
     assert get_task.call_count == 1
     assert update.call_count == 2
@@ -154,7 +155,10 @@ def test_celery_record_task_args_local_override(celery_session_app, celery_sessi
         assert result.get(timeout=10, propagate=True) == 4
 
     create.assert_called_once_with(
-        "tests.test_celery_system_integration.add_normal_with_override", status=StatusEnum.PENDING, queue="celery"
+        "tests.test_celery_system_integration.add_normal_with_override",
+        status=StatusEnum.PENDING,
+        queue="celery",
+        external_id=mock.ANY,
     )
 
 
@@ -189,6 +193,7 @@ def test_celery_global_tags(celery_session_app, celery_session_worker):
         status=StatusEnum.PENDING,
         tags=TaskRequestTags.from_dict({"tag1": "value1", "tag2": "override"}),
         queue="celery",
+        external_id=result.id,
     )
     create.assert_called_with(
         client=mock.ANY,

--- a/tests/test_procrastinate.py
+++ b/tests/test_procrastinate.py
@@ -115,7 +115,10 @@ def test_defer_creates_pending_task_and_injects_id(app):
     _instrument_task(add3, system=None, manual=True)
 
     tb = task_for_test()
-    with mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create:
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create,
+        mock.patch("taskbadger.procrastinate.update_task_safe"),
+    ):
         add3.defer(a=1, b=2)
 
     create.assert_called_once()
@@ -137,7 +140,10 @@ def test_defer_sets_queue(app):
     _instrument_task(add_queued, system=None, manual=True)
 
     tb = task_for_test()
-    with mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create:
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create,
+        mock.patch("taskbadger.procrastinate.update_task_safe"),
+    ):
         add_queued.defer(a=1, b=2)
 
     assert create.call_args.kwargs["queue"] == "high_priority"
@@ -168,11 +174,67 @@ def test_defer_async_injects_id(app):
     _instrument_task(add5, system=None, manual=True)
 
     tb = task_for_test()
-    with mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb):
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb),
+        mock.patch("taskbadger.procrastinate.update_task_safe"),
+    ):
         asyncio.run(add5.defer_async(a=1, b=2))
 
     jobs = list(app.connector.jobs.values())
     assert jobs[0]["args"][TB_TASK_ID_KWARG] == tb.id
+
+
+@pytest.mark.usefixtures("_bind_settings")
+def test_defer_records_job_id_as_external_id(app):
+    @app.task(name="add_ext")
+    def add_ext(a, b):
+        return a + b
+
+    _instrument_task(add_ext, system=None, manual=True)
+
+    tb = task_for_test()
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb),
+        mock.patch("taskbadger.procrastinate.update_task_safe") as update,
+    ):
+        job_id = add_ext.defer(a=1, b=2)
+
+    update.assert_called_once_with(tb.id, external_id=str(job_id))
+
+
+@pytest.mark.usefixtures("_bind_settings")
+def test_defer_async_records_job_id_as_external_id(app):
+    @app.task(name="add_ext_async")
+    async def add_ext_async(a, b):
+        return a + b
+
+    _instrument_task(add_ext_async, system=None, manual=True)
+
+    tb = task_for_test()
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb),
+        mock.patch("taskbadger.procrastinate.update_task_safe") as update,
+    ):
+        job_id = asyncio.run(add_ext_async.defer_async(a=1, b=2))
+
+    update.assert_called_once_with(tb.id, external_id=str(job_id))
+
+
+def test_defer_no_external_id_when_untracked(app):
+    @app.task(name="add_untracked")
+    def add_untracked(a, b):
+        return a + b
+
+    _instrument_task(add_untracked, system=None, manual=True)
+
+    # Badger is not configured, so no pending task is created and nothing to update.
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=None),
+        mock.patch("taskbadger.procrastinate.update_task_safe") as update,
+    ):
+        add_untracked.defer(a=1, b=2)
+
+    update.assert_not_called()
 
 
 @pytest.mark.usefixtures("_bind_settings")
@@ -194,7 +256,7 @@ def test_end_to_end_via_worker(app):
         app.run_worker(wait=False, install_signal_handlers=False, listen_notify=False)
 
     create.assert_called_once()
-    statuses = [c.kwargs["status"] for c in update.call_args_list]
+    statuses = [c.kwargs["status"] for c in update.call_args_list if "status" in c.kwargs]
     assert statuses == [StatusEnum.PROCESSING, StatusEnum.SUCCESS]
 
 
@@ -206,7 +268,10 @@ def test_track_bare_form(app):
         return a
 
     tb = task_for_test()
-    with mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb):
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb),
+        mock.patch("taskbadger.procrastinate.update_task_safe"),
+    ):
         bare.defer(a=1)
 
     assert getattr(bare, "_taskbadger_manual") is True
@@ -223,7 +288,10 @@ def test_track_parameterized(app):
         return a
 
     tb = task_for_test()
-    with mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create:
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create,
+        mock.patch("taskbadger.procrastinate.update_task_safe"),
+    ):
         raw.defer(a=1)
 
     create.assert_called_once()
@@ -248,7 +316,10 @@ def test_track_idempotent(app):
     # Two @track applications must not double-wrap; defer once still creates one
     # PENDING task and injects one id.
     tb = task_for_test()
-    with mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create:
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create,
+        mock.patch("taskbadger.procrastinate.update_task_safe"),
+    ):
         dup.defer(a=1)
     assert create.call_count == 1
     jobs = list(app.connector.jobs.values())
@@ -312,7 +383,7 @@ def test_user_set_terminal_state_not_overwritten(app):
 
     # The wrapper's post-call SUCCESS update is skipped because the cached
     # task is already SUCCESS. PROCESSING update is still allowed (early path).
-    statuses = [c.kwargs["status"] for c in update.call_args_list]
+    statuses = [c.kwargs["status"] for c in update.call_args_list if "status" in c.kwargs]
     assert StatusEnum.PROCESSING in statuses
     # Last attempted SUCCESS call should be suppressed
     assert statuses.count(StatusEnum.SUCCESS) == 0
@@ -326,7 +397,10 @@ def test_record_task_args_stores_kwargs(app):
         return a + b
 
     tb = task_for_test()
-    with mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create:
+    with (
+        mock.patch("taskbadger.procrastinate.create_task_safe", return_value=tb) as create,
+        mock.patch("taskbadger.procrastinate.update_task_safe"),
+    ):
         recorder.defer(a=5, b=6)
 
     assert create.call_args.kwargs["data"] == {

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -124,6 +124,31 @@ def test_update_queue(settings, patched_update):
     _verify_update(settings, patched_update, queue="high_priority")
 
 
+def test_create_with_external_id(settings, patched_create):
+    api_task = task_for_test()
+    patched_create.return_value = Response(HTTPStatus.OK, b"", {}, api_task)
+
+    Task.create(name="task name", external_id="celery-abc-123")
+
+    request = TaskRequest(name="task name", status=StatusEnum.PENDING, external_id="celery-abc-123")
+    patched_create.assert_called_with(
+        client=mock.ANY,
+        organization_slug="org",
+        project_slug="project",
+        body=request,
+    )
+
+
+def test_update_external_id(settings, patched_update):
+    api_task = task_for_test()
+    task = Task(api_task)
+
+    patched_update.return_value = Response(HTTPStatus.OK, b"", {}, api_task)
+    task.update(external_id="celery-abc-123")
+
+    _verify_update(settings, patched_update, external_id="celery-abc-123")
+
+
 def test_before_create_update_task(settings, patched_create):
     def before_create(task):
         tags = task.setdefault("tags", {})


### PR DESCRIPTION
Uses the new task `external_id` field (server taskbadger/taskbadger#413) to automatically record the originating framework's task ID, so a Task Badger task can be correlated with the Celery/Procrastinate job when digging through logs. Also exposes `external_id` on the public SDK (`create_task`/`update_task`/`Task.create`/`Task.update`), mirroring `queue`.

Worth knowing:
- **Celery** records the task ID for free at creation (`headers["id"]` / `request.id`). **Procrastinate**'s job ID is DB-assigned and only known *after* `defer()` returns, so it's recorded via one follow-up PATCH at enqueue time (covers `defer`, `defer_async`, and periodic jobs).
- `internal/` was updated by hand rather than committing the full `invoke update-api` regeneration: the pinned generator drifts unrelated code from `dateutil.isoparse` to `datetime.fromisoformat`, which can't parse a trailing `Z` on Python 3.10 (a supported version). The hand-edits match the generator's `external_id` output exactly.
- The Celery handler reuses a class-level `taskbadger_kwargs` dict across invocations; that dict is now copied before mutation so a per-publish `external_id` can't leak to the next publish (regression test included).

No version bump included — left for release time.